### PR TITLE
Add split slider and adjust color opacity

### DIFF
--- a/global.R
+++ b/global.R
@@ -2,6 +2,7 @@ library(shiny)
 library(leaflet)
 library(leaflet.minicharts)
 library(leaflet.extras)
+library(leaflet.extras2)
 library(plotly)
 
 area_df <- read.table(header=TRUE, text="
@@ -57,9 +58,26 @@ area_df$year <- as.character(area_df$year)
 
 # LULC class color palette & icons (add/edit if needed)
 class_palette <- data.frame(
-  class_eng = c("Water", "Forest", "Wetland", "Agriculture", "Built Area", "Bare Ground", "Snow/Ice", "Clouds", "Rangeland"),
-  color = c("#2596be", "#41ae42", "#b6e0b6", "#ffe55c", "#df4242", "#d6c99a", "#cccccc", "#b2b6b6", "#efbc2f"),
-  icon = c("fa-water", "fa-tree", "fa-water", "fa-seedling", "fa-city", "fa-mountain", "fa-snowflake", "fa-cloud", "fa-tractor")
+  class_eng = c(
+    "Water", "Forest", "Wetland", "Agriculture", "Built Area",
+    "Bare Ground", "Snow/Ice", "Clouds", "Rangeland"
+  ),
+  color = c(
+    "rgba(37,150,190,0.7)",  # Water
+    "rgba(65,174,66,0.7)",   # Forest
+    "rgba(182,224,182,0.7)", # Wetland
+    "rgba(255,229,92,0.7)",  # Agriculture
+    "rgba(223,66,66,0.7)",   # Built Area
+    "rgba(214,201,154,0.7)", # Bare Ground
+    "rgba(204,204,204,0.7)", # Snow/Ice
+    "rgba(178,182,182,0.7)", # Clouds
+    "rgba(239,188,47,0.7)"   # Rangeland
+  ),
+  icon = c(
+    "fa-water", "fa-tree", "fa-water", "fa-seedling",
+    "fa-city", "fa-mountain", "fa-snowflake", "fa-cloud",
+    "fa-tractor"
+  )
 )
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/server.R
+++ b/server.R
@@ -1,108 +1,104 @@
 source("global.R")
 
 server <- function(input, output, session) {
-  # Helper: Render each LULC map, synced
-  makeLULCMapSimple <- function(tiler_url) {
-    leaflet(options = leafletOptions(zoomControl = TRUE)) %>%
-      addProviderTiles("Esri.WorldImagery", group = "Satellite") %>%
-      addTiles(
-        urlTemplate = tiler_url,
-        options     = tileOptions(opacity = 0.75),
-        group       = "LULC"
+  output$big_map <- renderLeaflet({
+    m <- leaflet(options = leafletOptions(zoomControl = TRUE)) %>%
+      addProviderTiles("Esri.WorldImagery", group = "Satellite")
+    for (yr in names(lulc_urls)) {
+      m <- m %>% addTiles(
+        urlTemplate = lulc_urls[[yr]],
+        options     = tileOptions(opacity = 0.7),
+        group       = yr
+      )
+    }
+    m %>%
+      hideGroup(as.character(2019:2022)) %>%
+      addLayersControl(
+        baseGroups = c("Satellite"),
+        overlayGroups = names(lulc_urls),
+        options = layersControlOptions(collapsed = FALSE)
       ) %>%
+      addSplitMap("Satellite", "2023") %>%
       addResetMapButton() %>%
-      setView(lng = 29.0, lat = 41.1, zoom = 12) %>%
-      syncWith("maps")
-  }
-  
-  # Render LULC maps
-  for (yr in names(lulc_urls)) {
-    local({
-      year_str    <- yr
-      url_for_map <- lulc_urls[[year_str]]
-      output_name <- paste0("map", year_str)
-      output[[output_name]] <- renderLeaflet({
-        makeLULCMapSimple(url_for_map)
-      })
-    })
-  }
-  
-  # Render Area tables
-  for (yr in names(lulc_urls)) {
-    local({
-      year_str <- yr
-      output[[paste0("area_tbl_", year_str)]] <- renderUI({
-        dat <- subset(area_df, year == year_str)
-        if (nrow(dat) == 0) return(NULL)
-        dat <- merge(dat, class_palette, by = "class_eng", all.x = TRUE)
-        tags$table(class = "area-table",
-                   tags$thead(
-                     tags$tr(
-                       tags$th("Class"),
-                       tags$th("Area (ha)")
-                     )
-                   ),
-                   tags$tbody(
-                     lapply(seq_len(nrow(dat)), function(i) {
-                       tags$tr(
-                         tags$td(
-                           tags$span(
-                             class = "area-class-icon",
-                             style = paste0("color:", dat$color[i]),
-                             tags$i(class = paste("fa", dat$icon[i]))
-                           ),
-                           tags$span(dat$class_eng[i])
-                         ),
-                         tags$td(
-                           tags$span(style = paste0("color:", dat$color[i]),
-                                     formatC(dat$area_ha[i], digits = 0, big.mark = ",", format = "f")
-                           )
-                         )
+      setView(lng = 29.0, lat = 41.1, zoom = 12)
+  })
+
+  selected_year <- reactive({
+    groups <- input$big_map_groups
+    yrs <- intersect(names(lulc_urls), groups)
+    if (length(yrs) == 0) {
+      "2023"
+    } else {
+      tail(yrs, 1)
+    }
+  })
+
+  output$area_tbl_big <- renderUI({
+    year_str <- selected_year()
+    dat <- subset(area_df, year == year_str)
+    if (nrow(dat) == 0) return(NULL)
+    dat <- merge(dat, class_palette, by = "class_eng", all.x = TRUE)
+    tags$table(class = "area-table",
+               tags$thead(
+                 tags$tr(
+                   tags$th("Class"),
+                   tags$th("Area (ha)")
+                 )
+               ),
+               tags$tbody(
+                 lapply(seq_len(nrow(dat)), function(i) {
+                   tags$tr(
+                     tags$td(
+                       tags$span(
+                         class = "area-class-icon",
+                         style = paste0("color:", dat$color[i]),
+                         tags$i(class = paste("fa", dat$icon[i]))
+                       ),
+                       tags$span(dat$class_eng[i])
+                     ),
+                     tags$td(
+                       tags$span(style = paste0("color:", dat$color[i]),
+                                 formatC(dat$area_ha[i], digits = 0, big.mark = ",", format = "f")
                        )
-                     })
+                     )
                    )
-        )
-      })
-    })
-  }
-  
-  # Render Pie Charts under each table
-  for (yr in names(lulc_urls)) {
-    local({
-      year_str <- yr
-      output[[paste0("pie_", year_str)]] <- renderPlotly({
-        dat <- subset(area_df, year == year_str)
-        if (nrow(dat) == 0) return(NULL)
-        dat <- merge(dat, class_palette, by = "class_eng", all.x = TRUE)
-        dat <- dat[order(match(dat$class_eng, class_palette$class_eng)), ]
-        total_area <- sum(dat$area_ha)
-        dat$perc <- round(100 * dat$area_ha / total_area, 2)
-        plot_ly(
-          dat,
-          labels = ~class_eng,
-          values = ~area_ha,
-          type = 'pie',
-          textinfo = 'percent',            # Only show percent in chart
-          textposition = 'inside',
-          hoverinfo = 'label+percent+value', # Show all info on hover
-          marker = list(colors = dat$color,
-                        line = list(color = '#fff', width = 1)),
-          showlegend = FALSE,
-          sort = FALSE,
-          direction = "clockwise",
-          insidetextorientation = "auto"
-        ) %>%
-          layout(
-            margin = list(l = 0, r = 0, b = 0, t = 10, pad = 0),
-            height = 250,    # Increase or decrease as needed for your card
-            width = 250,
-            font = list(size = 16, family="Arial Black"),
-            paper_bgcolor = 'rgba(0,0,0,0)',
-            plot_bgcolor = 'rgba(0,0,0,0)'
-          )
-      })
-    })
-  }
+                 })
+               )
+    )
+  })
+
+  output$big_pie <- renderPlotly({
+    year_str <- selected_year()
+    dat <- subset(area_df, year == year_str)
+    if (nrow(dat) == 0) return(NULL)
+    dat <- merge(dat, class_palette, by = "class_eng", all.x = TRUE)
+    dat <- dat[order(match(dat$class_eng, class_palette$class_eng)), ]
+    total_area <- sum(dat$area_ha)
+    dat$perc <- round(100 * dat$area_ha / total_area, 2)
+    plot_ly(
+      dat,
+      labels = ~class_eng,
+      values = ~area_ha,
+      type = 'pie',
+      textinfo = 'percent',
+      textposition = 'inside',
+      hoverinfo = 'label+percent+value',
+      marker = list(colors = dat$color,
+                    line = list(color = '#fff', width = 1)),
+      showlegend = FALSE,
+      sort = FALSE,
+      direction = "clockwise",
+      insidetextorientation = "auto"
+    ) %>%
+      layout(
+        margin = list(l = 0, r = 0, b = 0, t = 10, pad = 0),
+        height = 250,
+        width = 250,
+        font = list(size = 16, family = "Arial Black"),
+        paper_bgcolor = 'rgba(0,0,0,0)',
+        plot_bgcolor = 'rgba(0,0,0,0)'
+      )
+  })
   
   
   # Forest area trend line

--- a/ui.R
+++ b/ui.R
@@ -41,26 +41,19 @@ ui <- fluidPage(
       .lulc-legend-dot {
         width: 13px; height: 13px; border-radius: 50%; display: inline-block;
         margin-right: 5px; border: 1.1px solid #bbb;
+        opacity: 0.7;
       }
       .lulc-legend-icon {
         margin-right: 4px; opacity: 0.92; font-size: 1em;
       }
-      .map-sync-container {
-        display: flex; flex-wrap: wrap; justify-content: center; gap: 18px; padding: 10px;
-      }
-      .map-card {
-        flex: 1 1 320px; min-width: 280px; max-width: 420px;
+      .main-map-container {
+        max-width: 1100px; margin: 0 auto 20px auto; padding: 10px;
         background: #fff; border-radius: 14px; box-shadow: 0 3px 15px rgba(0,0,0,0.09);
-        margin-bottom: 16px;
-        overflow: hidden; position: relative; display: flex; flex-direction: column;
-        transition: box-shadow .18s; border: 1.2px solid #f0f1f5;
       }
-      .map-card-title {
-        background: linear-gradient(90deg,#0092ff88,#41ae4288);
-        color: #fff; font-weight: 900 !important; padding: 8px 18px 6px 15px;
-        font-size: 1.25rem; letter-spacing: 0.5px; border-bottom: 1.5px solid #e5f4ee;
+      .map-below-wrapper {
+        display: flex; justify-content: space-between; align-items: flex-start;
+        gap: 12px; flex-wrap: wrap; padding-top: 10px;
       }
-      .map-card .leaflet-container { min-height: 235px; border-radius: 0 0 7px 7px; z-index: 2; }
       .area-table-container {
         background: #f9fbe8; font-size: 1.18rem; border-top: 1.7px solid #e4e4e4;
         width: 100%; z-index: 6; min-height: 100px;
@@ -79,10 +72,7 @@ ui <- fluidPage(
       .area-class-icon { font-size: 1.23em; margin-right: 7px; font-weight: 900 !important; }
       .area-table td span { font-size: 1.21em !important; font-weight: 900 !important; }
       .lulc-legend-icon { font-size: 1.2em !important; }
-      *, .app-header, .app-subtitle, .map-card-title, .lulc-legend-item, .area-table, .area-table th, .area-table td, .area-class-icon, .lulc-legend-sticky { font-weight: 900 !important; }
-      @media (max-width: 600px) {
-        .map-card { flex: 1 1 100%; min-width: 100%; max-width: 100%; }
-      }
+      *, .app-header, .app-subtitle, .lulc-legend-item, .area-table, .area-table th, .area-table td, .area-class-icon, .lulc-legend-sticky { font-weight: 900 !important; }
     "))
   ),
   tags$div(class = "app-header", "Land Use / Land Cover Dashboard"),
@@ -98,19 +88,13 @@ ui <- fluidPage(
     })
   ),
   div(
-    class = "map-sync-container",
-    lapply(names(lulc_urls), function(yr) {
-      div(
-        class = "map-card",
-        div(class = "map-card-title", paste0("LULC ", yr)),
-        leafletOutput(outputId = paste0("map", yr), height = 235),
-        uiOutput(paste0("area_tbl_", yr), class = "area-table-container"),
-        div(
-          style = "display: flex; justify-content: center; align-items: center; min-height: 260px;",
-          plotlyOutput(paste0("pie_", yr), height = "250px", width = "250px")
-        )
-      )
-    })
+    class = "main-map-container",
+    leafletOutput("big_map", height = "520px"),
+    div(
+      class = "map-below-wrapper",
+      plotlyOutput("big_pie", height = "320px", width = "320px"),
+      uiOutput("area_tbl_big", class = "area-table-container")
+    )
   ),
   # Forest Trend Line Graph
   div(


### PR DESCRIPTION
## Summary
- make legend colors semi-transparent and update `class_palette`
- use `addSplitMap` to show a swipe slider between base and LULC layers
- set map tile opacity to 70%
- adjust legend dot CSS for transparency
- load `leaflet.extras2` so split slider works
- revamp UI to show single big map with year layers and dynamic pie chart

## Testing
- `R -q -e "1+1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684243e46a04833285a76ed93e99c7c2