### PR TITLE
Add swipe control for comparing LULC years

### DIFF
--- a/server.R
+++ b/server.R
@@ -2,6 +2,8 @@ source("global.R")
 
 server <- function(input, output, session) {
   output$big_map <- renderLeaflet({
+    left  <- input$left_year
+    right <- input$right_year
     m <- leaflet(options = leafletOptions(zoomControl = TRUE)) %>%
       addProviderTiles("Esri.WorldImagery", group = "Satellite")
     for (yr in names(lulc_urls)) {
@@ -12,25 +14,19 @@ server <- function(input, output, session) {
       )
     }
     m %>%
-      hideGroup(as.character(2019:2022)) %>%
+      hideGroup(setdiff(names(lulc_urls), c(left, right))) %>%
       addLayersControl(
         baseGroups = c("Satellite"),
         overlayGroups = names(lulc_urls),
         options = layersControlOptions(collapsed = FALSE)
       ) %>%
-      # leaflet.extras2::addSplitMap("Satellite", "2023") %>%
+      leaflet.extras2::addSplitMap(left, right) %>%
       addResetMapButton() %>%
       setView(lng = 29.0, lat = 41.1, zoom = 12)
   })
 
   selected_year <- reactive({
-    groups <- input$big_map_groups
-    yrs <- intersect(names(lulc_urls), groups)
-    if (length(yrs) == 0) {
-      "2023"
-    } else {
-      tail(yrs, 1)
-    }
+    input$right_year
   })
 
   output$area_tbl_big <- renderUI({

--- a/ui.R
+++ b/ui.R
@@ -46,6 +46,11 @@ ui <- fluidPage(
       .lulc-legend-icon {
         margin-right: 4px; opacity: 0.92; font-size: 1em;
       }
+      .swipe-controls {
+        display: flex; justify-content: center; gap: 10px;
+        margin: 10px 0; flex-wrap: wrap;
+      }
+      .swipe-controls .form-group { margin-bottom: 0; }
       .main-map-container {
         max-width: 1100px; margin: 0 auto 20px auto; padding: 10px;
         background: #fff; border-radius: 14px; box-shadow: 0 3px 15px rgba(0,0,0,0.09);
@@ -86,6 +91,11 @@ ui <- fluidPage(
                 class_palette$class_eng[i]
       )
     })
+  ),
+  div(
+    class = "swipe-controls",
+    selectInput("left_year", "Left Year", choices = years, selected = 2019),
+    selectInput("right_year", "Right Year", choices = years, selected = 2023)
   ),
   div(
     class = "main-map-container",


### PR DESCRIPTION
## Summary
- add dropdowns to pick left and right map years
- show split map using `leaflet.extras2::addSplitMap`
- style swipe controls
- link the right map year to the stats table and pie chart

## Testing
- `Rscript -e 'print(1)'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684283c53a088332912596a5dfd2e108